### PR TITLE
Minor Fix - Login Redirect

### DIFF
--- a/src/main/g8/src/main/scala/$package$/snippet/UserSnips.scala
+++ b/src/main/g8/src/main/scala/$package$/snippet/UserSnips.scala
@@ -15,6 +15,7 @@ import http.js.JsCmds._
 import util._
 import Helpers._
 
+import net.liftmodules.mongoauth.LoginRedirect
 import net.liftmodules.mongoauth.model.ExtSession
 
 sealed trait UserSnippet extends AppHelpers with Loggable {
@@ -122,7 +123,7 @@ object UserLogin extends Loggable {
               User.logUserIn(user, true)
               if (remember) User.createExtSession(user.id.is)
               else ExtSession.deleteExtCookie()
-              RedirectTo(Site.home.url)
+              RedirectTo(LoginRedirect.openOr(Site.home.url))
             case _ =>
               S.error("Invalid credentials")
               Noop


### PR DESCRIPTION
The RequireLoggedIn LocParam sets the LoginRedirect session var to reflect the original page the user was accessing before being prompted to login.  The UserLogin snippet was ignoring this session var however, instead always redirecting home upon a successful login.
